### PR TITLE
TOPS-1049 - fix dataform access

### DIFF
--- a/blueprints/data-solutions/data-platform-minimal/01-landing.tf
+++ b/blueprints/data-solutions/data-platform-minimal/01-landing.tf
@@ -26,10 +26,10 @@ locals {
       local.looker_sa_iam_email
     ]
    "roles/bigquery.jobUser" = [
-      local.dataform_sa_iam_email,
-      local.groups_iam.data-engineers,
-      local.looker_sa_iam_email,
-      module.processing-sa-0.iam_email
+     local.dataform_sa_iam_email,
+     local.groups_iam.data-engineers,
+     local.looker_sa_iam_email,
+     module.processing-sa-0.iam_email
    ]
   }
 }

--- a/blueprints/data-solutions/data-platform-minimal/01-landing.tf
+++ b/blueprints/data-solutions/data-platform-minimal/01-landing.tf
@@ -21,8 +21,8 @@ locals {
     "roles/storage.objectAdmin"   = [module.processing-sa-0.iam_email]
     "roles/bigquery.dataEditor"   = [module.processing-sa-0.iam_email]
     "roles/bigquery.dataViewer" = [
-      local.dataform_sa_iam_email,
       local.groups_iam.data-engineers,
+      local.dataform_sa_iam_email,
       local.looker_sa_iam_email
     ]
    "roles/bigquery.jobUser" = [

--- a/blueprints/data-solutions/data-platform-minimal/01-landing.tf
+++ b/blueprints/data-solutions/data-platform-minimal/01-landing.tf
@@ -26,7 +26,6 @@ locals {
       local.looker_sa_iam_email
     ]
    "roles/bigquery.jobUser" = [
-     local.dataform_sa_iam_email,
      local.groups_iam.data-engineers,
      local.looker_sa_iam_email,
      module.processing-sa-0.iam_email

--- a/blueprints/data-solutions/data-platform-minimal/01-landing.tf
+++ b/blueprints/data-solutions/data-platform-minimal/01-landing.tf
@@ -21,14 +21,15 @@ locals {
     "roles/storage.objectAdmin"   = [module.processing-sa-0.iam_email]
     "roles/bigquery.dataEditor"   = [module.processing-sa-0.iam_email]
     "roles/bigquery.dataViewer" = [
-      local.groups_iam.data-engineers,
       local.dataform_sa_iam_email,
+      local.groups_iam.data-engineers,
       local.looker_sa_iam_email
     ]
    "roles/bigquery.jobUser" = [
-     local.groups_iam.data-engineers,
-     local.looker_sa_iam_email,
-     module.processing-sa-0.iam_email
+      local.dataform_sa_iam_email,
+      local.groups_iam.data-engineers,
+      local.looker_sa_iam_email,
+      module.processing-sa-0.iam_email
    ]
   }
 }

--- a/blueprints/data-solutions/data-platform-minimal/03-curated.tf
+++ b/blueprints/data-solutions/data-platform-minimal/03-curated.tf
@@ -16,8 +16,7 @@
 
 locals {
   cur_iam = {
-    "roles/bigquery.dataEditor" = [local.dataform_sa_iam_email]
-    "roles/bigquery.dataOwner" = [module.processing-sa-0.iam_email]
+    "roles/bigquery.dataOwner"  = [module.processing-sa-0.iam_email]
     "roles/bigquery.dataViewer" = [
       module.cur-sa-0.iam_email,
       local.groups_iam.data-analysts,

--- a/blueprints/data-solutions/data-platform-minimal/03-curated.tf
+++ b/blueprints/data-solutions/data-platform-minimal/03-curated.tf
@@ -16,7 +16,7 @@
 
 locals {
   cur_iam = {
-    "roles/bigquery.dataOwner"  = [module.processing-sa-0.iam_email]
+    "roles/bigquery.dataOwner" = [module.processing-sa-0.iam_email]
     "roles/bigquery.dataViewer" = [
       module.cur-sa-0.iam_email,
       local.groups_iam.data-analysts,


### PR DESCRIPTION
this commit removes default dataform SA roles/bigquery.dataEditor on all curated project
it will now only be granted on dev curated and that will be done in `platform-gcp` repo 

platform-gcp PR https://github.com/timeoutdigital/platform-gcp/pull/98
